### PR TITLE
Improve Queues

### DIFF
--- a/pwos/include/pwos/common.h
+++ b/pwos/include/pwos/common.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <mutex>
 #include <numeric>
+#include <algorithm>
 
 using std::mutex;
 using std::string;

--- a/pwos/include/pwos/common.h
+++ b/pwos/include/pwos/common.h
@@ -106,7 +106,8 @@ const map<string, IntegratorType> StrToIntegratorType({
 enum class StatTimerType
 {
     TOTAL,
-    QUEUE,
+    SEND_WALKS,
+    RECV_WALKS,
     CLOSEST_POINT_GRID,
     CLOSEST_POINT_QUERY,
     SETUP

--- a/pwos/include/pwos/integrators/wog.h
+++ b/pwos/include/pwos/integrators/wog.h
@@ -10,17 +10,15 @@
 class WoG: public Integrator
 {
 public:
+    float rrProb = 0.99;
     float cellLength, minGridR;
     shared_ptr<ClosestPointGrid> cpg;
 
     WoG(Scene scene, Vec2i res = Vec2i(128, 128), int spp = 16, int nthreads = 1)
     : Integrator("wog", scene, res, spp, nthreads)
-    {};
-
-    void virtual render() override
     {
         // preprocess by computing closest point grid
-        Vec4f window = scene->getWindow();
+        Vec4f window = this->scene->getWindow();
         Vec2f bl(window[0], window[1]);
         Vec2f tr(window[2], window[3]);
         float dx = tr.x() - bl.x();
@@ -28,11 +26,13 @@ public:
 
         // ensures cells are basically width of a pixel
         // precompute grid
-        Vec2i res = image->getRes();
         cellLength = std::min(dx / res.x(), dy / res.y());
         minGridR = sqrt(2) * cellLength;
-        cpg = make_shared<ClosestPointGrid>(scene, bl, tr, cellLength, nthreads);
+        cpg = make_shared<ClosestPointGrid>(this->scene, bl, tr, cellLength, nthreads);
+    };
 
+    void virtual render() override
+    {
         image->render(scene->getWindow(), nthreads, [this](Vec2f coord, pcg32& sampler) -> Vec3f
         {
             Vec3f pixelValue(0, 0, 0);
@@ -45,8 +45,6 @@ public:
     }
 
 private:
-    float rrProb = 0.99;
-
     Vec3f u_hat(Vec2f x0, pcg32 &sampler) const
     {
         Vec2f p = x0;

--- a/pwos/include/pwos/integrators/wog.h
+++ b/pwos/include/pwos/integrators/wog.h
@@ -26,7 +26,7 @@ public:
 
         // ensures cells are basically width of a pixel
         // precompute grid
-        cellLength = std::min(dx / res.x(), dy / res.y());
+        cellLength = 0.01 * std::min(dx / res.x(), dy / res.y());
         minGridR = sqrt(2) * cellLength;
         cpg = make_shared<ClosestPointGrid>(this->scene, bl, tr, cellLength, nthreads);
     };

--- a/pwos/include/pwos/stats.h
+++ b/pwos/include/pwos/stats.h
@@ -14,8 +14,11 @@ public:
     // the total run time for each thread
     inline static vector<fsec> threadTime;
 
-    // How long each thread spends accessing the random walk queue
-    inline static vector<fsec> threadQueueTime;
+    // How long each thread spends sending random walks
+    inline static vector<fsec> threadSendWalksTime;
+
+    // How long each thread spends receiving random walks
+    inline static vector<fsec> threadRecvWalksTime;
 
     // How long each thread spends reading from memory (ClosestPointGrid Queries)
     inline static vector<fsec> threadCPGTime;

--- a/pwos/src/stats.cpp
+++ b/pwos/src/stats.cpp
@@ -78,11 +78,11 @@ void Stats::report()
     std::cout << "|     Profiling Results                 |" << std::endl;
     std::cout << "-----------------------------------------" << std::endl;
 
-    std::cout << "Number of Closest Point Queries:\t\t" << numClosestPointQueries << std::endl;
-    std::cout << "Number of Grid Queries:\t\t" << numGridQueries << std::endl;
+    std::cout << "Number of Closest Point Queries: " << numClosestPointQueries << std::endl;
+    std::cout << "Number of Grid Queries:" << numGridQueries << std::endl;
 
-    std::cout << "\t total time:" << totalTime.count() << std::endl;
-    std::cout << "\t setup time:" << setupTime.count() << std::endl;
+    std::cout << "Total time:" << totalTime.count() << std::endl;
+    std::cout << "Setup time:" << setupTime.count() << std::endl;
 
     // average of thread times
     int nthreads = threadTime.size();
@@ -94,16 +94,20 @@ void Stats::report()
         threadCPGTimeF.push_back(threadCPGTime[i].count());
         threadCPQTimeF.push_back(threadCPQTime[i].count());
     }
+    auto [minThreadTime, maxThreadTime] = std::minmax_element(threadTimeF.begin(), threadTimeF.end());
+    auto [minQueueTime, maxQueueTime] = std::minmax_element(threadQueueTimeF.begin(), threadQueueTimeF.end());
+    auto [minCPGTime, maxCPGTime] = std::minmax_element(threadCPGTimeF.begin(), threadCPGTimeF.end());
+    auto [minCPQTime, maxCPQTime] = std::minmax_element(threadCPQTimeF.begin(), threadCPQTimeF.end());
 
     float avgThreadTime = std::accumulate(threadTimeF.begin(), threadTimeF.end(), 0.0f) / float(nthreads);
     float avgQueueTime = std::accumulate(threadQueueTimeF.begin(), threadQueueTimeF.end(), 0.0f) / float(nthreads);
     float avgCPGTime = std::accumulate(threadCPGTimeF.begin(), threadCPGTimeF.end(), 0.0f) / float(nthreads);
     float avgCPQTime = std::accumulate(threadCPQTimeF.begin(), threadCPQTimeF.end(), 0.0f) / float(nthreads);
 
-    std::cout << "\t avg time per thread: " << avgThreadTime << std::endl;
-    std::cout << "\t avg queue time: " << avgQueueTime << std::endl;
-    std::cout << "\t avg CP Grid time: " << avgCPGTime << std::endl;
-    std::cout << "\t avg CP Query time: " << avgCPQTime << std::endl;
+    std::cout << "Time per thread: " << "( avg=" << avgThreadTime << ", min=" << *minThreadTime << ", max="<< *maxThreadTime << ")" << std::endl;
+    std::cout << "Queue time: " << avgQueueTime << ", min=" << *minQueueTime << ", max="<< *maxQueueTime << ")" << std::endl;
+    std::cout << "CP Grid time: " << avgCPGTime << ", min=" << *minCPGTime << ", max="<< *maxCPGTime << ")" << std::endl;
+    std::cout << "CP Query time: " << avgCPQTime << ", min=" << *minCPQTime << ", max="<< *maxCPQTime << ")" << std::endl;
 
     // Distribution of thread times
     if (nthreads > 1) 

--- a/pwos/src/stats.cpp
+++ b/pwos/src/stats.cpp
@@ -13,7 +13,8 @@ void Stats::reset()
 void Stats::initTimers(int nthreads)
 {
     threadTime = vector<fsec>(nthreads);
-    threadQueueTime = vector<fsec>(nthreads);
+    threadSendWalksTime = vector<fsec>(nthreads);
+    threadRecvWalksTime = vector<fsec>(nthreads);
     threadCPGTime = vector<fsec>(nthreads);
     threadCPQTime = vector<fsec>(nthreads);
 }
@@ -43,8 +44,11 @@ void Stats::TIME_THREAD(size_t tid, StatTimerType type, FunctionBlock f)
         case StatTimerType::TOTAL:
             threadTime[tid] += Time::now() - start;
             break;
-        case StatTimerType::QUEUE:
-            threadQueueTime[tid] += Time::now() - start;
+        case StatTimerType::SEND_WALKS:
+            threadSendWalksTime[tid] += Time::now() - start;
+            break;
+     case StatTimerType::RECV_WALKS:
+            threadRecvWalksTime[tid] += Time::now() - start;
             break;
         case StatTimerType::CLOSEST_POINT_GRID:
             threadCPGTime[tid] += Time::now() - start;
@@ -86,26 +90,30 @@ void Stats::report()
 
     // average of thread times
     int nthreads = threadTime.size();
-    std::vector<float> threadTimeF, threadQueueTimeF, threadCPGTimeF, threadCPQTimeF;
+    std::vector<float> threadTimeF, threadSendWalksTimeF, threadRecvWalksTimeF, threadCPGTimeF, threadCPQTimeF;
     for (int i = 0; i < nthreads; i++)
     {
         threadTimeF.push_back(threadTime[i].count());
-        threadQueueTimeF.push_back(threadQueueTime[i].count());
+        threadSendWalksTimeF.push_back(threadSendWalksTime[i].count());
+        threadRecvWalksTimeF.push_back(threadRecvWalksTime[i].count());
         threadCPGTimeF.push_back(threadCPGTime[i].count());
         threadCPQTimeF.push_back(threadCPQTime[i].count());
     }
     auto [minThreadTime, maxThreadTime] = std::minmax_element(threadTimeF.begin(), threadTimeF.end());
-    auto [minQueueTime, maxQueueTime] = std::minmax_element(threadQueueTimeF.begin(), threadQueueTimeF.end());
+    auto [minSendWalksTime, maxSendWalksTime] = std::minmax_element(threadSendWalksTimeF.begin(), threadSendWalksTimeF.end());
+    auto [minRecvWalksTime, maxRecvWalksTime] = std::minmax_element(threadRecvWalksTimeF.begin(), threadRecvWalksTimeF.end());
     auto [minCPGTime, maxCPGTime] = std::minmax_element(threadCPGTimeF.begin(), threadCPGTimeF.end());
     auto [minCPQTime, maxCPQTime] = std::minmax_element(threadCPQTimeF.begin(), threadCPQTimeF.end());
 
     float avgThreadTime = std::accumulate(threadTimeF.begin(), threadTimeF.end(), 0.0f) / float(nthreads);
-    float avgQueueTime = std::accumulate(threadQueueTimeF.begin(), threadQueueTimeF.end(), 0.0f) / float(nthreads);
+    float avgSendWalksTime = std::accumulate(threadSendWalksTimeF.begin(), threadSendWalksTimeF.end(), 0.0f) / float(nthreads);
+    float avgRecvWalksTime = std::accumulate(threadRecvWalksTimeF.begin(), threadRecvWalksTimeF.end(), 0.0f) / float(nthreads);
     float avgCPGTime = std::accumulate(threadCPGTimeF.begin(), threadCPGTimeF.end(), 0.0f) / float(nthreads);
     float avgCPQTime = std::accumulate(threadCPQTimeF.begin(), threadCPQTimeF.end(), 0.0f) / float(nthreads);
 
     std::cout << "Time per thread: " << "( avg=" << avgThreadTime << ", min=" << *minThreadTime << ", max="<< *maxThreadTime << ")" << std::endl;
-    std::cout << "Queue time: " << avgQueueTime << ", min=" << *minQueueTime << ", max="<< *maxQueueTime << ")" << std::endl;
+    std::cout << "Send Walks time: " << avgSendWalksTime << ", min=" << *minSendWalksTime << ", max="<< *maxSendWalksTime << ")" << std::endl;
+    std::cout << "Recv Walks time: " << avgRecvWalksTime << ", min=" << *minRecvWalksTime << ", max="<< *maxRecvWalksTime << ")" << std::endl;
     std::cout << "CP Grid time: " << avgCPGTime << ", min=" << *minCPGTime << ", max="<< *maxCPGTime << ")" << std::endl;
     std::cout << "CP Query time: " << avgCPQTime << ", min=" << *minCPQTime << ", max="<< *maxCPQTime << ")" << std::endl;
 


### PR DESCRIPTION
- use WAY more queues (one-way queues, two per each pair of threads)
- don't use locks when sending message own queue (i.e. send to self)
- avoid grabbing lock when queue is empty
- for each queue, add two queues under the hood so that there is no waiting on locks (i.e. when reading, always try to lock and then read both (skip if lock not available) when writing, write to the queue that isn't locked)
- move progress updates out of main loop so they only happen once for every completed pixel (same disadvantage/slow down that all the other algorithms have so makes comparisons more fair)
